### PR TITLE
Fix HSET on Redis Server < 4.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ _build
 # Environment
 .env
 
+# Redis
+dump.rdb

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,8 @@ Changelog
 Releases
 --------
 
+- 0.9.1:
+    - **Version compatibility** - The collection classes now accept a ``hmset_command`` keyword argument. This is set to ``hmset`` for compatibility with Redis server versions before 4.0.0. Set it to ``hset`` to avoid a ``DeprecationWarning`` from `redis-py`.
 - 0.9.0:
     - **Breaking change**: The Python 2-style methods ``.iteritems()``, ``.iterkeys()``, and ``.itervalues()`` have been removed from ``Dict`` and its subclasses. The ``.iter()`` method was also removed.
     - **Version compatibility**: This library now supports Python 3.6 and higher.

--- a/redis_collections/__init__.py
+++ b/redis_collections/__init__.py
@@ -1,5 +1,5 @@
 __title__ = 'redis-collections'
-__version__ = '0.9.0'
+__version__ = '0.9.1'
 __author__ = 'Honza Javorek'
 __license__ = 'ISC'
 __copyright__ = 'Copyright 2013-? Honza Javorek'

--- a/tests/base.py
+++ b/tests/base.py
@@ -14,7 +14,7 @@ class RedisTestCase(unittest.TestCase):
 
     def setUp(self):
         self.redis = redis.StrictRedis.from_url(
-            f'redis://{REDIS_HOST}:{REDIS_PORT}', db=self.db
+            'redis://{}:{}'.format(REDIS_HOST, REDIS_PORT), db=self.db
         )
         if self.redis.dbsize():
             raise EnvironmentError(

--- a/tests/test_dicts.py
+++ b/tests/test_dicts.py
@@ -430,10 +430,9 @@ class DictTest(RedisTestCase):
         d |= redis_list
         self.assertEqual(sorted(d.items()), [('a', 'h'), ('c', 42), ('x', 38)])
 
-
     def test_hmset(self):
         d = self.create_dict(hmset_command='hset')
-        if d.redis_version < (4, 0 , 0):
+        if d.redis_version < (4, 0, 0):
             self.skipTest('Test required redis >= 4.0.0')
         d.update({1: 2, 3: 4})
 

--- a/tests/test_dicts.py
+++ b/tests/test_dicts.py
@@ -431,6 +431,13 @@ class DictTest(RedisTestCase):
         self.assertEqual(sorted(d.items()), [('a', 'h'), ('c', 42), ('x', 38)])
 
 
+    def test_hmset(self):
+        d = self.create_dict(hmset_command='hset')
+        if d.redis_version < (4, 0 , 0):
+            self.skipTest('Test required redis >= 4.0.0')
+        d.update({1: 2, 3: 4})
+
+
 class CounterTest(RedisTestCase):
     def create_counter(self, *args, **kwargs):
         kwargs['redis'] = self.redis

--- a/tests/test_sortedsets.py
+++ b/tests/test_sortedsets.py
@@ -1,4 +1,4 @@
-from redis_collections import GeoDB, SortedSetCounter
+from redis_collections import Dict, GeoDB, SortedSetCounter
 
 from .base import RedisTestCase
 
@@ -240,6 +240,12 @@ class SortedSetCounterTestCase(RedisTestCase):
 
 
 class GeoDBTestCase(RedisTestCase):
+    def setUp(self):
+        super().setUp()
+        d = Dict(redis=self.redis)
+        if d.redis_version < (3, 2, 0):
+            self.skipTest('Test requires redis >= 3.2.0')
+
     def create_geodb(self, *args, **kwargs):
         kwargs['redis'] = self.redis
         return GeoDB(*args, **kwargs)


### PR DESCRIPTION
Re: https://github.com/redis-collections/redis-collections/issues/141, this PR:
* Adds an `hmset_command` keyword argument to the collections
* By default this is `'hmset'`, which should work on all current versions of Redis server and `redis-py`
* It can be set to `'hset'` if `redis-py`'s `DeprecationWarning` is a problem

In the next release I will remove support for versions of Redis server below 4.0.0. When `redis-py` drops the `hmset` command I will remove the keyword argument.