### PR TITLE
Make Syncable collections sync atomically

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9.0, 3.10.0-beta.1]
+        python-version: [3.6, 3.7, 3.8, 3.9.0, 3.10.0-alpha.7]
 
     services:
       redis:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,9 @@ Changelog
 Releases
 --------
 
+- 0.10.0:
+    - **Bending change**: The Syncable collections (like ``SyncableDict``) have been updated such that their ``.sync()`` methods are atomic.
+      This requires additional storage on Redis when syncing, so be aware of space constraints.
 - 0.9.1:
     - **Version compatibility** - The collection classes now accept a ``hmset_command`` keyword argument. This is set to ``hmset`` for compatibility with Redis server versions before 4.0.0. Set it to ``hset`` to avoid a ``DeprecationWarning`` from `redis-py`.
 - 0.9.0:
@@ -62,8 +65,8 @@ Versioning
 A 1.0 release is planned. Before that happens:
 
 - Releases with significant new features or breaking changes will be tagged as
-  0.10.x, 0.11.x, etc.
-- Bug fix releases will be tagged as 0.8.x
+  0.11.x, 0.12.x, etc.
+- Bug fix releases will be tagged as 0.10.x
 
 After 1.0 is released:
 

--- a/redis_collections/__init__.py
+++ b/redis_collections/__init__.py
@@ -1,5 +1,5 @@
 __title__ = 'redis-collections'
-__version__ = '0.9.1'
+__version__ = '0.10.0'
 __author__ = 'Honza Javorek'
 __license__ = 'ISC'
 __copyright__ = 'Copyright 2013-? Honza Javorek'

--- a/redis_collections/syncable.py
+++ b/redis_collections/syncable.py
@@ -29,6 +29,12 @@ be loaded.
 The underlying :class:`RedisCollection` instance can be accessed from the
 ``persistence`` attribute.
 
+.. note::
+    The synchronization process will transfer all local items to a new
+    key in Redis and then overwrite the original key with the
+    `RENAME <https://redis.io/commands/rename>`__ operation.
+    This might not be appropriate for very large collections.
+
 """
 import collections.abc as collections_abc
 import collections
@@ -70,8 +76,8 @@ class SyncableDict(_SyncableBase, dict):
         self.update(self.persistence)
 
     def sync(self):
-        self.persistence.clear()
-        self.persistence.update(self)
+        tempdict = Dict(redis=self.redis, data=self)
+        self.redis.rename(tempdict.key, self.key)
 
 
 class SyncableCounter(_SyncableBase, collections.Counter):
@@ -91,8 +97,8 @@ class SyncableCounter(_SyncableBase, collections.Counter):
         self.update(self.persistence)
 
     def sync(self):
-        self.persistence.clear()
-        self.persistence.update(self)
+        tempcounter = Counter(redis=self.redis, data=self)
+        self.redis.rename(tempcounter.key, self.key)
 
 
 class SyncableDefaultDict(_SyncableBase, collections.defaultdict):
@@ -112,8 +118,8 @@ class SyncableDefaultDict(_SyncableBase, collections.defaultdict):
         self.update(self.persistence)
 
     def sync(self):
-        self.persistence.clear()
-        self.persistence.update(self)
+        tempddict = DefaultDict(redis=self.redis, data=self)
+        self.redis.rename(tempddict.key, self.key)
 
 
 class SyncableList(_SyncableBase, list):
@@ -132,8 +138,8 @@ class SyncableList(_SyncableBase, list):
         self.extend(self.persistence)
 
     def sync(self):
-        self.persistence.clear()
-        self.persistence.extend(self)
+        templist = List(redis=self.redis, data=self)
+        self.redis.rename(templist.key, self.key)
 
 
 class SyncableDeque(_SyncableBase, collections.deque):
@@ -152,8 +158,8 @@ class SyncableDeque(_SyncableBase, collections.deque):
         self.extend(self.persistence)
 
     def sync(self):
-        self.persistence.clear()
-        self.persistence.extend(self)
+        tempq = Deque(redis=self.redis, data=self)
+        self.redis.rename(tempq.key, self.key)
 
 
 class SyncableSet(_SyncableBase, set):
@@ -172,8 +178,8 @@ class SyncableSet(_SyncableBase, set):
         self.update(self.persistence)
 
     def sync(self):
-        self.persistence.clear()
-        self.persistence.update(self)
+        tempset = Set(redis=self.redis, data=self)
+        self.redis.rename(tempset.key, self.key)
 
 
 class LRUDict(_SyncableBase, collections_abc.MutableMapping):

--- a/redis_collections/syncable.py
+++ b/redis_collections/syncable.py
@@ -59,6 +59,10 @@ class _SyncableBase:
     def __exit__(self, exc_type, exc_value, traceback):
         self.sync()
 
+    def sync(self):
+        temp_collection = self.persistence_cls(redis=self.redis, data=self)
+        self.redis.rename(temp_collection.key, self.key)
+
 
 class SyncableDict(_SyncableBase, dict):
     """
@@ -69,15 +73,12 @@ class SyncableDict(_SyncableBase, dict):
     details.
     """
 
+    persistence_cls = Dict
+
     def __init__(self, **kwargs):
         self.persistence = Dict(**kwargs)
-
         super().__init__()
         self.update(self.persistence)
-
-    def sync(self):
-        tempdict = Dict(redis=self.redis, data=self)
-        self.redis.rename(tempdict.key, self.key)
 
 
 class SyncableCounter(_SyncableBase, collections.Counter):
@@ -90,15 +91,12 @@ class SyncableCounter(_SyncableBase, collections.Counter):
     for details.
     """
 
+    persistence_cls = Counter
+
     def __init__(self, **kwargs):
         self.persistence = Counter(**kwargs)
-
         super().__init__()
         self.update(self.persistence)
-
-    def sync(self):
-        tempcounter = Counter(redis=self.redis, data=self)
-        self.redis.rename(tempcounter.key, self.key)
 
 
 class SyncableDefaultDict(_SyncableBase, collections.defaultdict):
@@ -111,15 +109,12 @@ class SyncableDefaultDict(_SyncableBase, collections.defaultdict):
     #collections.defaultdict>`_ for details.
     """
 
+    persistence_cls = DefaultDict
+
     def __init__(self, *args, **kwargs):
         self.persistence = DefaultDict(*args, **kwargs)
-
         super().__init__(args[0] if args else None)
         self.update(self.persistence)
-
-    def sync(self):
-        tempddict = DefaultDict(redis=self.redis, data=self)
-        self.redis.rename(tempddict.key, self.key)
 
 
 class SyncableList(_SyncableBase, list):
@@ -131,15 +126,12 @@ class SyncableList(_SyncableBase, list):
     #sequence-types-list-tuple-range>`__ for details.
     """
 
+    persistence_cls = List
+
     def __init__(self, **kwargs):
         self.persistence = List(**kwargs)
-
         super().__init__()
         self.extend(self.persistence)
-
-    def sync(self):
-        templist = List(redis=self.redis, data=self)
-        self.redis.rename(templist.key, self.key)
 
 
 class SyncableDeque(_SyncableBase, collections.deque):
@@ -151,15 +143,12 @@ class SyncableDeque(_SyncableBase, collections.deque):
     for details.
     """
 
+    persistence_cls = Deque
+
     def __init__(self, iterable=None, maxlen=None, **kwargs):
         self.persistence = Deque(iterable=iterable, maxlen=maxlen, **kwargs)
-
         super().__init__(maxlen=self.persistence.maxlen)
         self.extend(self.persistence)
-
-    def sync(self):
-        tempq = Deque(redis=self.redis, data=self)
-        self.redis.rename(tempq.key, self.key)
 
 
 class SyncableSet(_SyncableBase, set):
@@ -171,15 +160,12 @@ class SyncableSet(_SyncableBase, set):
     #set-types-set-frozenset>`__ for details.
     """
 
+    persistence_cls = Set
+
     def __init__(self, **kwargs):
         self.persistence = Set(**kwargs)
-
         super().__init__()
         self.update(self.persistence)
-
-    def sync(self):
-        tempset = Set(redis=self.redis, data=self)
-        self.redis.rename(tempset.key, self.key)
 
 
 class LRUDict(_SyncableBase, collections_abc.MutableMapping):

--- a/tests/test_syncable.py
+++ b/tests/test_syncable.py
@@ -107,6 +107,7 @@ class SyncableTest(RedisTestCase):
         del ddict_1['A']
         ddict_1.sync()
         self.assertNotIn('A', ddict_1.persistence)
+        self.assertEqual(ddict_1['A'], 0)
 
         # The default_factory can be changed between synchronizations
         key_1 = ddict_1.key


### PR DESCRIPTION
Re: https://github.com/redis-collections/redis-collections/issues/144, this PR updates the `Syncable` collections such that their `sync` operation is atomic. The method here is: copy all local data to Redis using a new key, then rename the old key to the new key.