### PR TITLE
Version 0.11.0

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        sw-version: [[3.6, 6.2], [3.7, 6.2], [3.8, 6.2], [3.9, 6.2], [3.9, 2.6], [3.9, 2.8], [3.9, 3.2], [3.9, 4.0], [3.9, 5.0], [3.9, 6.0], [3.10.0-beta.4, latest]]
+        sw-version: [[3.7, 6.2], [3.8, 6.2], [3.9, 6.2], [3.9, 2.6], [3.9, 2.8], [3.9, 3.2], [3.9, 4.0], [3.9, 5.0], [3.9, 6.0], [3.10.2, latest]]
 
     services:
       redis:
@@ -43,28 +43,28 @@ jobs:
         REDIS_HOST: redis
         REDIS_PORT: 6379
     - name: Lint with flake8
-      if: "matrix.sw-version[0] == '3.6'"
+      if: "matrix.sw-version[0] == '3.7'"
       run: |
         pip install -U flake8
         flake8 .
     - name: Check formatting with black
-      if: "matrix.sw-version[0] == '3.6'"
+      if: "matrix.sw-version[0] == '3.7'"
       run: |
         pip install -U black
         black --check .
     - name: Build docs with sphinx
-      if: "matrix.sw-version[0] == '3.6'"
+      if: "matrix.sw-version[0] == '3.7'"
       run: |
         pip install -U sphinx sphinx_rtd_theme
         sphinx-build -W -b html docs docs/_build/html
     - name: Build packages
-      if: "matrix.sw-version[0] == '3.6'"
+      if: "matrix.sw-version[0] == '3.7'"
       run: |
         pip install -U twine wheel
         python setup.py sdist bdist_wheel
         twine check dist/*
     - name: Upload packages
-      if: "matrix.sw-version[0] == '3.6'"
+      if: "matrix.sw-version[0] == '3.7'"
       uses: actions/upload-artifact@v2
       with:
         name: redis-collections-packages

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,9 @@ Changelog
 Releases
 --------
 
+- 0.11.0:
+    - **Version compatibility**: This library now supports Python 3.7 and higher.
+    - **Version compatibility** - This library now supports `redis-py` version 4.x (thanks to lionelnicolas)
 - 0.10.0:
     - **Bending change**: The Syncable collections (like ``SyncableDict``) have been updated such that their ``.sync()`` methods are atomic.
       This requires additional storage on Redis when syncing, so be aware of space constraints.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,7 +8,7 @@ Releases
 
 - 0.11.0:
     - **Version compatibility**: This library now supports Python 3.7 and higher.
-    - **Version compatibility** - This library now supports `redis-py` version 4.x (thanks to lionelnicolas)
+    - **Version compatibility** - This library now supports `redis-py` version 4.x (thanks to lionelnicolas). The minimum supported version is now 3.5.x.
 - 0.10.0:
     - **Bending change**: The Syncable collections (like ``SyncableDict``) have been updated such that their ``.sync()`` methods are atomic.
       This requires additional storage on Redis when syncing, so be aware of space constraints.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,28 @@
+# What we want
+Sphinx==4.4.0
+
+# What we get
+alabaster==0.7.12
+Babel==2.9.1
+certifi==2021.10.8
+charset-normalizer==2.0.10
+docutils==0.17.1
+idna==3.3
+imagesize==1.3.0
+importlib-metadata==4.10.1
+Jinja2==3.0.3
+MarkupSafe==2.0.1
+packaging==21.3
+Pygments==2.11.2
+pyparsing==3.0.6
+pytz==2021.3
+requests==2.27.1
+snowballstemmer==2.2.0
+sphinxcontrib-applehelp==1.0.2
+sphinxcontrib-devhelp==1.0.2
+sphinxcontrib-htmlhelp==2.0.0
+sphinxcontrib-jsmath==1.0.1
+sphinxcontrib-qthelp==1.0.3
+sphinxcontrib-serializinghtml==1.1.5
+urllib3==1.26.8
+zipp==3.7.0

--- a/redis_collections/__init__.py
+++ b/redis_collections/__init__.py
@@ -1,5 +1,5 @@
 __title__ = 'redis-collections'
-__version__ = '0.10.0'
+__version__ = '0.11.0'
 __author__ = 'Honza Javorek'
 __license__ = 'ISC'
 __copyright__ = 'Copyright 2013-? Honza Javorek'

--- a/redis_collections/sortedsets.py
+++ b/redis_collections/sortedsets.py
@@ -536,8 +536,7 @@ class GeoDB(SortedSetBase):
 
         *place* can be any pickle-able Python object.
         """
-        pipe = self.redis if pipe is None else pipe
-        pipe.geoadd(self.key, longitude, latitude, self._pickle(place))
+        self._geoadd(longitude, latitude, self._pickle(place), pipe=pipe)
 
     def update(self, other):
         """

--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,8 @@ setup(
     license='ISC',
     packages=find_packages(exclude=['tests']),
     include_package_data=True,
-    python_requires='>=3.4',
-    install_requires=['redis>=3.1.0,<4.0.0'],
+    python_requires='>=3.7',
+    install_requires=['redis>=3.5.0,<5.0.0'],
     zip_safe=False,
     keywords=['redis', 'persistence'],
     classifiers=(

--- a/tests/test_sets.py
+++ b/tests/test_sets.py
@@ -403,7 +403,7 @@ class SetTest(RedisTestCase):
             self.assertEqual(s.pop(), elem_2)
 
     def test_add_equal_hashes(self):
-        redis_set = Set()
+        redis_set = self.create_set()
         python_set = set()
         for value in [
             1.0,


### PR DESCRIPTION
This PR incorporates the change @lionelnicolas suggested in #147 as well as some others:
* Python version support: since 3.6 is EOL, Python 3.7 is now the lowest supported version
* Redis-py version support: since 4.1/x is out, 3.5.x is now the lowest support version.

I'll release this to PyPI shortly.