### PR TITLE
LRUDict: copy the local cache only when using sync

### DIFF
--- a/redis_collections/syncable.py
+++ b/redis_collections/syncable.py
@@ -289,7 +289,7 @@ class LRUDict(_SyncableBase, collections_abc.MutableMapping):
         If *clear_cache* is ``True``, clear out the local cache after
         pushing its items to Redis.
         """
-        self.persistence.update(self)
+        self.persistence.update(self.cache)
 
         if clear_cache:
             self.cache.clear()


### PR DESCRIPTION
This PR updates `LRUDict` such that it only copies items from its local cache during the `sync` operation.

Thanks to @beckermr for the suggestion.
 
Closes #151